### PR TITLE
Fix package.json references to curl.js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.2.0",
   "author": "John Foster",
   "description": "Support for using highlight.js to syntax highlight cURL commands.",
-  "main": "src/languages/curl.min.js",
+  "main": "src/languages/curl.js",
   "scripts": {
     "test": "jasmine"
   },
   "files": [
-    "src/language/curl.js"
+    "src/languages/curl.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current npm package installs without any js files downloaded. I believe its because these file paths are incorrect.